### PR TITLE
fix(react-native): do not wrap constraint into or/and operator if there is only one constraint

### DIFF
--- a/react-native/firestore/useCompositeFilter.ts
+++ b/react-native/firestore/useCompositeFilter.ts
@@ -38,6 +38,10 @@ export const buildCompositeFilter = <DbModelType extends CompositeFilterDocument
             return null;
         }
 
+        if (queryConstraints.length <= 1) {
+            return queryConstraints[0];
+        }
+
         return (query as CompositeFilter).operator === "OR" ? or(...queryConstraints) : and(...queryConstraints);
     }
 
@@ -73,6 +77,11 @@ export const useCompositeFilter = <DbModelType extends CompositeFilterDocumentDa
         if (queryConstraints.length <= 0) {
             return undefined;
         }
+
+        if (queryConstraints.length <= 1) {
+            return queryConstraints[0];
+        }
+
         return query?.operator === "OR" ? or(...queryConstraints) : and(...queryConstraints);
     }, [query]);
 };


### PR DESCRIPTION
# Description

For some reason react-native-firebase module does not allow to pass single parameter inside and/or operator functions.
