### PR TITLE
feat(firestore): adds useEnsureDoc hook

### DIFF
--- a/react-native/firestore/index.ts
+++ b/react-native/firestore/index.ts
@@ -20,3 +20,4 @@ export * from "./utils/getDocSnap";
 export * from "./utils/getDocRef";
 export * from "./utils/buildQueryConstraint";
 export * from "./utils/buildCompositeFilter";
+export * from "./useEnsureDoc";

--- a/react-native/firestore/useEnsureDoc.ts
+++ b/react-native/firestore/useEnsureDoc.ts
@@ -1,0 +1,79 @@
+import { useQuery, UseQueryOptions } from "@tanstack/react-query";
+import { getDoc, setDoc } from "@react-native-firebase/firestore";
+
+import { AppModel } from "../../types";
+import { GetDocDataOptions } from "./utils/getDocData";
+import { getDocRef } from "./utils/getDocRef";
+import { getDocSnap } from "./utils/getDocSnap";
+import { useFirestore } from "./useFirestore";
+
+/**
+ * @inline
+ */
+export type UseEnsureDocOptions<AppModelType extends AppModel = AppModel> = {
+    /**
+     * Reference to a document that must be written
+     */
+    defaults: AppModelType;
+
+    /**
+     * Options for useMutation hook excluding mutationFn.
+     */
+    options: Omit<UseQueryOptions<AppModelType, Error, AppModelType>, "queryFn"> &
+        Required<Pick<UseQueryOptions<AppModelType, Error, AppModelType>, "queryKey">>;
+} & Omit<GetDocDataOptions<AppModelType>, "db">;
+
+/**
+ * This hook checks if a doc with a requested reference exists.
+ * It creates a document with requested data if it does not exist.
+ *
+ * @group Hook
+ *
+ * @param {UseEnsureDocOptions<AppModelType>} options - Configuration options for mutation.
+ *
+ * @returns {UseQueryResult<AppModelType, Error>}  A mutation result
+ *
+ * @example
+ * ```jsx
+ * export const MyComponent = () => {
+ *  const {data} = useEnsureDocQuery({
+ *      options: {
+ *      },
+ *      reference: collection().doc(),
+ *      defaults: {prop1: 'value1'}
+ *  });
+ *
+ * };
+ * ```
+ */
+export const useEnsureDoc = <AppModelType extends AppModel = AppModel>({
+    reference,
+    path,
+    pathSegments,
+    defaults,
+    options
+}: UseEnsureDocOptions<AppModelType>) => {
+    const db = useFirestore();
+
+    return useQuery({
+        ...options,
+        queryFn: async () => {
+            const existingDocSnap = await getDocSnap({ db, path, pathSegments, reference });
+
+            if (existingDocSnap?.exists) {
+                return { ...(existingDocSnap.data() as AppModelType), uid: existingDocSnap.id };
+            }
+
+            const docRef = getDocRef({ db, reference, path, pathSegments });
+            if (!docRef) {
+                throw new Error(
+                    `Cannot fetch document reference using data: ${reference?.path}, ${path}, ${pathSegments?.join("/")}`
+                );
+            }
+
+            await setDoc<AppModelType>(docRef, defaults);
+            const docSnap = await getDoc(docRef);
+            return { ...(docSnap.data() as AppModelType), uid: docSnap.id };
+        }
+    });
+};

--- a/web/firestore/index.ts
+++ b/web/firestore/index.ts
@@ -15,6 +15,7 @@ export * from "./useSetDocMutation";
 export * from "./useUpdateDocMutation";
 export * from "./useGetRealtimeDocData";
 export * from "./useQueryConstraints";
+export * from "./useEnsureDoc";
 export * from "./utils/getDocData";
 export * from "./utils/getDocSnap";
 export * from "./utils/getDocRef";

--- a/web/firestore/useEnsureDoc.ts
+++ b/web/firestore/useEnsureDoc.ts
@@ -1,0 +1,79 @@
+import { useQuery, UseQueryOptions } from "@tanstack/react-query";
+import { getDoc, setDoc } from "firebase/firestore";
+
+import { AppModel } from "../../types";
+import { GetDocDataOptions } from "./utils/getDocData";
+import { getDocRef } from "./utils/getDocRef";
+import { getDocSnap } from "./utils/getDocSnap";
+import { useFirestore } from "./useFirestore";
+
+/**
+ * @inline
+ */
+export type UseEnsureDocOptions<AppModelType extends AppModel = AppModel> = {
+    /**
+     * Reference to a document that must be written
+     */
+    defaults: AppModelType;
+
+    /**
+     * Options for useMutation hook excluding mutationFn.
+     */
+    options: Omit<UseQueryOptions<AppModelType, Error, AppModelType>, "queryFn"> &
+        Required<Pick<UseQueryOptions<AppModelType, Error, AppModelType>, "queryKey">>;
+} & Omit<GetDocDataOptions<AppModelType>, "db">;
+
+/**
+ * This hook checks if a doc with a requested reference exists.
+ * It creates a document with requested data if it does not exist.
+ *
+ * @group Hook
+ *
+ * @param {UseEnsureDocOptions<AppModelType>} options - Configuration options for mutation.
+ *
+ * @returns {UseQueryResult<AppModelType, Error>}  A mutation result
+ *
+ * @example
+ * ```jsx
+ * export const MyComponent = () => {
+ *  const {data} = useEnsureDocQuery({
+ *      options: {
+ *      },
+ *      reference: collection().doc(),
+ *      defaults: {prop1: 'value1'}
+ *  });
+ *
+ * };
+ * ```
+ */
+export const useEnsureDoc = <AppModelType extends AppModel = AppModel>({
+    reference,
+    path,
+    pathSegments,
+    defaults,
+    options
+}: UseEnsureDocOptions<AppModelType>) => {
+    const db = useFirestore();
+
+    return useQuery({
+        ...options,
+        queryFn: async () => {
+            const existingDocSnap = await getDocSnap({ db, path, pathSegments, reference });
+
+            if (existingDocSnap?.exists) {
+                return { ...(existingDocSnap.data() as AppModelType), uid: existingDocSnap.id };
+            }
+
+            const docRef = getDocRef({ db, reference, path, pathSegments });
+            if (!docRef) {
+                throw new Error(
+                    `Cannot fetch document reference using data: ${reference?.path}, ${path}, ${pathSegments?.join("/")}`
+                );
+            }
+
+            await setDoc<AppModelType, AppModelType>(docRef, defaults);
+            const docSnap = await getDoc(docRef);
+            return { ...(docSnap.data() as AppModelType), uid: docSnap.id };
+        }
+    });
+};


### PR DESCRIPTION
The purpose of this hook is to give consumer a way to make sure that a certain entity exists in DB.

Use-cases:
A user can sign in anonymously, so no registration is required as a result there is no way to call beforeUserCreated FB function. At the same time, a new user must have a settings object attached to it. By using this hook, we can ensure that a document for settings exists in DB and it either has default values or has already been modified by a user.
